### PR TITLE
Enable -O3 and -DNDEBUG for benchmarks.

### DIFF
--- a/EntityComponentSystemsTest/EntityComponentSystemsTest.xcodeproj/project.pbxproj
+++ b/EntityComponentSystemsTest/EntityComponentSystemsTest.xcodeproj/project.pbxproj
@@ -625,7 +625,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_OPTIMIZATION_LEVEL = 3;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
@@ -639,6 +639,10 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CPLUSPLUSFLAGS = (
+					"-DNDEBUG",
+					"$(OTHER_CFLAGS)",
+				);
 				SDKROOT = macosx;
 			};
 			name = Debug;
@@ -675,6 +679,10 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_CPLUSPLUSFLAGS = (
+					"-DNDEBUG",
+					"$(OTHER_CFLAGS)",
+				);
 				SDKROOT = macosx;
 			};
 			name = Release;


### PR DESCRIPTION
I'm the author of EntityX and a user reported the results of your [benchmarks](https://tilemapkit.com/2015/10/entity-component-systems-compared-benchmarked-entityx-anax-artemis/). Needless to say, I was quite surprised by the results, but after some digging I noticed that the benchmarks are invalid because they run in debug mode with all assertions enabled. EntityX uses asserts liberally in debug mode to perform consistency checks, so it is definitely going to be much slower in that case.

This PR fixes that. I'd appreciate it if you could re-run the benchmarks and update the blog post accordingly.

Additionally, I'm not sure the benchmark itself is really representative, as typically numerous entities will also be created and destroyed each frame (eg. explosions, bullets, etc.). Still, switching to a release-style build will definitely give a fairer comparison.

PS. I commented on your blog but it only showed up for the [http](http://tilemapkit.com/2015/10/entity-component-systems-compared-benchmarked-entityx-anax-artemis/) version, not the [https](https://tilemapkit.com/2015/10/entity-component-systems-compared-benchmarked-entityx-anax-artemis/) version. Strange.
